### PR TITLE
docs(snyk): Added Snyk badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hello-python-packaging
 
+[![Known Vulnerabilities](https://snyk.io/test/github/SafeEval/hello-python-packaging/badge.svg)](https://snyk.io/test/github/SafeEval/hello-python-packaging)
+
 Exploring Python package builds, versioning, releases, pipelines, and
 everything else that make a quality Python project "go."
 


### PR DESCRIPTION
Snyk documentation: https://support.snyk.io/hc/en-us/articles/360004032117-GitHub-integration#github-badges

The Snyk badges only work for public repositories. Can't change the text from "vulnerabilities" to say "Snyk," since dependency vulns aren't the only kind.

- The `main` branch: [![Known Vulnerabilities](https://snyk.io/test/github/SafeEval/hello-python-packaging/badge.svg)](https://snyk.io/test/github/SafeEval/hello-python-packaging)
- The `test-snyk1` branch: [![Known Vulnerabilities](https://snyk.io/test/github/SafeEval/hello-python-packaging/test-snyk1/badge.svg)](https://snyk.io/test/github/SafeEval/hello-python-packaging/test-snyk1)